### PR TITLE
[DPB][MLNX][YANG-models] extended regex pattern according to mlnx systems speeds requirements

### DIFF
--- a/src/sonic-yang-models/yang-models/sonic-breakout_cfg.yang
+++ b/src/sonic-yang-models/yang-models/sonic-breakout_cfg.yang
@@ -51,7 +51,7 @@ module sonic-breakout_cfg {
                          * Add any other breakout-mode to allow Dynamic Port
                          * Breakout to that breakout-mode.
                          */
-                        pattern '1x100G\[40G\]|2x50G|4x25G\[10G\]|2x25G\(2\)\+1x50G\(2\)|1x50G\(2\)\+2x25G\(2\)|1x400G|2x200G|4x100G|8x50G|1x200G\[100G,50G,40G,25G,10G,1G\]|2x100G\[50G,40G,25G,10G,1G\]|4x50G\[40G,25G,10G,1G\]';
+                        pattern '1x100G\[40G\]|2x50G|4x25G\[10G\]|2x25G\(2\)\+1x50G\(2\)|1x50G\(2\)\+2x25G\(2\)|1x400G|2x200G|4x100G|8x50G|1x200G\[100G,50G,40G,25G,10G,1G\]|2x100G\[50G,40G,25G,10G,1G\]|4x50G\[40G,25G,10G,1G\]|1x25G\[10G\]|1x100G\[50G,40G,25G,10G\]|2x50G\[40G,25G,10G\]|4x25G\[10G\]';
                     }
                 }
             }

--- a/src/sonic-yang-models/yang-models/sonic-breakout_cfg.yang
+++ b/src/sonic-yang-models/yang-models/sonic-breakout_cfg.yang
@@ -51,7 +51,7 @@ module sonic-breakout_cfg {
                          * Add any other breakout-mode to allow Dynamic Port
                          * Breakout to that breakout-mode.
                          */
-                        pattern '1x100G\[40G\]|2x50G|4x25G\[10G\]|2x25G\(2\)\+1x50G\(2\)|1x50G\(2\)\+2x25G\(2\)|1x400G|2x200G|4x100G|8x50G|1x200G\[100G,50G,40G,25G,10G,1G\]|2x100G\[50G,40G,25G,10G,1G\]|4x50G\[40G,25G,10G,1G\]|1x25G\[10G\]|1x100G\[50G,40G,25G,10G\]|2x50G\[40G,25G,10G\]|4x25G\[10G\]|1x25G\[10G,1G\]|1x100G\[50G,40G,25G,10G,1G\]|2x50G\[40G,25G,10G,1G\]|4x25G\[10G,1G\]';
+                        pattern '1x100G\[40G\]|2x50G|4x25G\[10G\]|2x25G\(2\)\+1x50G\(2\)|1x50G\(2\)\+2x25G\(2\)|1x400G|2x200G|4x100G|8x50G|1x200G\[100G,50G,40G,25G,10G,1G\]|2x100G\[50G,40G,25G,10G,1G\]|4x50G\[40G,25G,10G,1G\]|1x25G\[10G\]|1x100G\[50G,40G,25G,10G\]|2x50G\[40G,25G,10G\]|4x25G\[10G\]|1x25G\[10G,1G\]|1x100G\[50G,40G,25G,10G,1G\]|2x50G\[40G,25G,10G,1G\]|4x25G\[10G,1G\]|1x400G\[200G,100G,50G,40G,25G,10G,1G\]|2x200G\[100G,50G,40G,25G,10G,1G\]|4x100G\[50G,40G,25G,10G,1G\]';
                     }
                 }
             }

--- a/src/sonic-yang-models/yang-models/sonic-breakout_cfg.yang
+++ b/src/sonic-yang-models/yang-models/sonic-breakout_cfg.yang
@@ -51,7 +51,7 @@ module sonic-breakout_cfg {
                          * Add any other breakout-mode to allow Dynamic Port
                          * Breakout to that breakout-mode.
                          */
-                        pattern '1x100G\[40G\]|2x50G|4x25G\[10G\]|2x25G\(2\)\+1x50G\(2\)|1x50G\(2\)\+2x25G\(2\)|1x400G|2x200G|4x100G|8x50G|1x200G\[100G,50G,40G,25G,10G,1G\]|2x100G\[50G,40G,25G,10G,1G\]|4x50G\[40G,25G,10G,1G\]|1x25G\[10G\]|1x100G\[50G,40G,25G,10G\]|2x50G\[40G,25G,10G\]|4x25G\[10G\]';
+                        pattern '1x100G\[40G\]|2x50G|4x25G\[10G\]|2x25G\(2\)\+1x50G\(2\)|1x50G\(2\)\+2x25G\(2\)|1x400G|2x200G|4x100G|8x50G|1x200G\[100G,50G,40G,25G,10G,1G\]|2x100G\[50G,40G,25G,10G,1G\]|4x50G\[40G,25G,10G,1G\]|1x25G\[10G\]|1x100G\[50G,40G,25G,10G\]|2x50G\[40G,25G,10G\]|4x25G\[10G\]|1x25G\[10G,1G\]|1x100G\[50G,40G,25G,10G,1G\]|2x50G\[40G,25G,10G,1G\]|4x25G\[10G,1G\]';
                     }
                 }
             }

--- a/src/sonic-yang-models/yang-models/sonic-breakout_cfg.yang
+++ b/src/sonic-yang-models/yang-models/sonic-breakout_cfg.yang
@@ -51,7 +51,7 @@ module sonic-breakout_cfg {
                          * Add any other breakout-mode to allow Dynamic Port
                          * Breakout to that breakout-mode.
                          */
-                        pattern '1x100G\[40G\]|2x50G|4x25G\[10G\]|2x25G\(2\)\+1x50G\(2\)|1x50G\(2\)\+2x25G\(2\)|1x400G|2x200G|4x100G|8x50G';
+                        pattern '1x100G\[40G\]|2x50G|4x25G\[10G\]|2x25G\(2\)\+1x50G\(2\)|1x50G\(2\)\+2x25G\(2\)|1x400G|2x200G|4x100G|8x50G|1x200G\[100G,50G,40G,25G,10G,1G\]|2x100G\[50G,40G,25G,10G,1G\]|4x50G\[40G,25G,10G,1G\]';
                     }
                 }
             }

--- a/src/sonic-yang-models/yang-models/sonic-port.yang
+++ b/src/sonic-yang-models/yang-models/sonic-port.yang
@@ -63,7 +63,7 @@ module sonic-port{
 				leaf speed {
 					mandatory true;
 					type uint32 {
-						range 1..100000;
+						range 1..400000;
 					}
 				}
 


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

All MLNX platforms require DPB modes with a specific set of speeds [example](https://github.com/Azure/sonic-buildimage/pull/6021/files)

**- How I did it**

Extended regex pattern inside YANG model.

**- How to verify it**

Manually tested DPB CLI on all platform with all modes

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [x] master
- [ ] 201911

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
