### PR TITLE
[DPB][YANG] extended yang-model - added 'buffer_model' field

### DIFF
--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -89,6 +89,12 @@ module sonic-device_metadata {
                         pattern "ToRRouter|LeafRouter|SpineChassisFrontendRouter|ChassisBackendRouter|ASIC";
                     }
                 }
+
+                leaf buffer_model {
+                    type string {
+                        pattern "dynamic|traditional";
+                    }
+                }
             }
             /* end of container localhost */
         }


### PR DESCRIPTION
Signed-off-by: Vadym Hlushko <vadymh@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx" or "resolves #xxxx"

Please provide the following information:
-->

**- Why I did it**

The Dynamic Port Breakout feature requires all [YANG-models](https://github.com/Azure/sonic-buildimage/tree/master/src/sonic-yang-models/yang-models) to be fully aligned with CONFIG_DB.
If some engineer extends the CONFIG_DB with the new fields, those fields needed to be represented in the appropriate .yang file.

**- How I did it**

CONFIG_DB was extended with the field `buffer_model` - added representation of this field inside the  [sonic-device_metadata.yang](https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/yang-models/sonic-device_metadata.yang) 

**- How to verify it**

Run the command `config interface breakout <interface> <breakout_mode>`

**- Which release branch to backport (provide reason below if selected)**

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->
- [x] master
- [ ] 201811
- [ ] 201911
- [ ] 202006

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**
