### PR TITLE
internal [202205][buffers] Add 'create_only_config_db_buffers.json' files for the Mellanox devices (not MSFT SKU)

### DIFF
--- a/device/mellanox/x86_64-mlnx_msn2010-r0/ACS-MSN2010/create_only_config_db_buffers.json
+++ b/device/mellanox/x86_64-mlnx_msn2010-r0/ACS-MSN2010/create_only_config_db_buffers.json
@@ -1,0 +1,7 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "create_only_config_db_buffers": "true"
+        }
+    }
+}

--- a/device/mellanox/x86_64-mlnx_msn2100-r0/ACS-MSN2100/create_only_config_db_buffers.json
+++ b/device/mellanox/x86_64-mlnx_msn2100-r0/ACS-MSN2100/create_only_config_db_buffers.json
@@ -1,0 +1,7 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "create_only_config_db_buffers": "true"
+        }
+    }
+}

--- a/device/mellanox/x86_64-mlnx_msn2410-r0/ACS-MSN2410/create_only_config_db_buffers.json
+++ b/device/mellanox/x86_64-mlnx_msn2410-r0/ACS-MSN2410/create_only_config_db_buffers.json
@@ -1,0 +1,7 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "create_only_config_db_buffers": "true"
+        }
+    }
+}

--- a/device/mellanox/x86_64-mlnx_msn2700-r0/ACS-MSN2700/create_only_config_db_buffers.json
+++ b/device/mellanox/x86_64-mlnx_msn2700-r0/ACS-MSN2700/create_only_config_db_buffers.json
@@ -1,0 +1,7 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "create_only_config_db_buffers": "true"
+        }
+    }
+}

--- a/device/mellanox/x86_64-mlnx_msn2740-r0/ACS-MSN2740/create_only_config_db_buffers.json
+++ b/device/mellanox/x86_64-mlnx_msn2740-r0/ACS-MSN2740/create_only_config_db_buffers.json
@@ -1,0 +1,7 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "create_only_config_db_buffers": "true"
+        }
+    }
+}

--- a/device/mellanox/x86_64-mlnx_msn3420-r0/ACS-MSN3420/create_only_config_db_buffers.json
+++ b/device/mellanox/x86_64-mlnx_msn3420-r0/ACS-MSN3420/create_only_config_db_buffers.json
@@ -1,0 +1,7 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "create_only_config_db_buffers": "true"
+        }
+    }
+}

--- a/device/mellanox/x86_64-mlnx_msn3700-r0/ACS-MSN3700/create_only_config_db_buffers.json
+++ b/device/mellanox/x86_64-mlnx_msn3700-r0/ACS-MSN3700/create_only_config_db_buffers.json
@@ -1,0 +1,7 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "create_only_config_db_buffers": "true"
+        }
+    }
+}

--- a/device/mellanox/x86_64-mlnx_msn3700c-r0/ACS-MSN3700C/create_only_config_db_buffers.json
+++ b/device/mellanox/x86_64-mlnx_msn3700c-r0/ACS-MSN3700C/create_only_config_db_buffers.json
@@ -1,0 +1,7 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "create_only_config_db_buffers": "true"
+        }
+    }
+}

--- a/device/mellanox/x86_64-mlnx_msn3800-r0/ACS-MSN3800/create_only_config_db_buffers.json
+++ b/device/mellanox/x86_64-mlnx_msn3800-r0/ACS-MSN3800/create_only_config_db_buffers.json
@@ -1,0 +1,7 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "create_only_config_db_buffers": "true"
+        }
+    }
+}

--- a/device/mellanox/x86_64-mlnx_msn4410-r0/ACS-MSN4410/create_only_config_db_buffers.json
+++ b/device/mellanox/x86_64-mlnx_msn4410-r0/ACS-MSN4410/create_only_config_db_buffers.json
@@ -1,0 +1,7 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "create_only_config_db_buffers": "true"
+        }
+    }
+}

--- a/device/mellanox/x86_64-mlnx_msn4600-r0/ACS-MSN4600/create_only_config_db_buffers.json
+++ b/device/mellanox/x86_64-mlnx_msn4600-r0/ACS-MSN4600/create_only_config_db_buffers.json
@@ -1,0 +1,7 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "create_only_config_db_buffers": "true"
+        }
+    }
+}

--- a/device/mellanox/x86_64-mlnx_msn4600c-r0/ACS-MSN4600C/create_only_config_db_buffers.json
+++ b/device/mellanox/x86_64-mlnx_msn4600c-r0/ACS-MSN4600C/create_only_config_db_buffers.json
@@ -1,0 +1,7 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "create_only_config_db_buffers": "true"
+        }
+    }
+}

--- a/device/mellanox/x86_64-mlnx_msn4700-r0/ACS-MSN4700/create_only_config_db_buffers.json
+++ b/device/mellanox/x86_64-mlnx_msn4700-r0/ACS-MSN4700/create_only_config_db_buffers.json
@@ -1,0 +1,7 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "create_only_config_db_buffers": "true"
+        }
+    }
+}

--- a/device/mellanox/x86_64-nvidia_sn2201-r0/ACS-SN2201/create_only_config_db_buffers.json
+++ b/device/mellanox/x86_64-nvidia_sn2201-r0/ACS-SN2201/create_only_config_db_buffers.json
@@ -1,0 +1,7 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "create_only_config_db_buffers": "true"
+        }
+    }
+}

--- a/device/mellanox/x86_64-nvidia_sn4800-r0/ACS-SN4800/create_only_config_db_buffers.json
+++ b/device/mellanox/x86_64-nvidia_sn4800-r0/ACS-SN4800/create_only_config_db_buffers.json
@@ -1,0 +1,7 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "create_only_config_db_buffers": "true"
+        }
+    }
+}

--- a/device/mellanox/x86_64-nvidia_sn5600-r0/ACS-SN5600/create_only_config_db_buffers.json
+++ b/device/mellanox/x86_64-nvidia_sn5600-r0/ACS-SN5600/create_only_config_db_buffers.json
@@ -1,0 +1,7 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "create_only_config_db_buffers": "true"
+        }
+    }
+}

--- a/device/mellanox/x86_64-nvidia_sn5600_simx-r0/ACS-SN5600/create_only_config_db_buffers.json
+++ b/device/mellanox/x86_64-nvidia_sn5600_simx-r0/ACS-SN5600/create_only_config_db_buffers.json
@@ -1,0 +1,7 @@
+{
+    "DEVICE_METADATA": {
+        "localhost": {
+            "create_only_config_db_buffers": "true"
+        }
+    }
+}

--- a/files/build_templates/docker_image_ctl.j2
+++ b/files/build_templates/docker_image_ctl.j2
@@ -335,6 +335,18 @@ start() {
         MOUNTPATH="$MOUNTPATH/$DEV"
     fi
     {%- endif %}
+
+    {%- if docker_container_name == "swss" %}
+    # Insert "create_only_config_db_buffers" attribute
+    HWSKU_FOLDER="/usr/share/sonic/device/$PLATFORM/$HWSKU"
+    if [ -d "$HWSKU_FOLDER" ]; then
+        CREATE_ONLY_CONFIG_DB_BUFFERS_JSON="$HWSKU_FOLDER/create_only_config_db_buffers.json"
+        if [ -f "$CREATE_ONLY_CONFIG_DB_BUFFERS_JSON" ]; then
+            $SONIC_CFGGEN -j $CREATE_ONLY_CONFIG_DB_BUFFERS_JSON --write-to-db
+        fi
+    fi
+    {%- endif %}
+
     DOCKERCHECK=`docker inspect --type container ${DOCKERNAME} 2>/dev/null`
     if [ "$?" -eq "0" ]; then
         {%- if docker_container_name == "database" %}

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/device_metadata.json
@@ -120,6 +120,12 @@
     "DEVICE_METADATA_INVALID_RACK_MGMT_MAP": {
         "desc": "Verifying invalid rack_mgmt_map configuration.",
         "eStr": "Invalid length for the rack mgmt map."
+    },
+    "DEVICE_METADATA_VALID_CREATE_ONLY_CONFIG_DB_BUFFERS": {
+        "desc": "Verifying the create_only_config_db_buffers value"
+    },
+    "DEVICE_METADATA_INVALID_CREATE_ONLY_CONFIG_DB_BUFFERS": {
+        "desc": "Verifying invalid create_only_config_db_buffers value",
+        "eStrKey": "InvalidValue"
     }
-
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/device_metadata.json
@@ -329,5 +329,23 @@
                 }
             }
         }
+    },
+    "DEVICE_METADATA_VALID_CREATE_ONLY_CONFIG_DB_BUFFERS": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "create_only_config_db_buffers": "true"
+                }
+            }
+        }
+    },
+    "DEVICE_METADATA_INVALID_CREATE_ONLY_CONFIG_DB_BUFFERS": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "create_only_config_db_buffers": "invalid"
+                }
+            }
+        }
     }
 }

--- a/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
+++ b/src/sonic-yang-models/yang-models/sonic-device_metadata.yang
@@ -202,6 +202,14 @@ module sonic-device_metadata {
                     }
                     description "Information of rack mgmt map.";
                 }
+
+                leaf create_only_config_db_buffers {
+                    type boolean;
+                    description "If this attribute exists and is equal to true - the buffers will be created
+                                 according to the config_db configuration (for example BUFFER_QUEUE|* table),
+                                 otherwise the maximum available buffers (which are read from SAI) will be
+                                 created, regardless of the CONFIG_DB buffers configuration.";
+                }
             }
             /* end of container localhost */
         }


### PR DESCRIPTION

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211
- [ ] 202305

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

